### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/energy-monitoring.json
+++ b/energy-monitoring.json
@@ -697,7 +697,7 @@
                     ]
                 },
                 "ReservedConcurrentExecutions": 3,
-                "Runtime": "python3.7",
+                "Runtime": "python3.10",
                 "Handler": "index.lambda_handler",
                 "Environment": {
                     "Variables": {


### PR DESCRIPTION
CloudFormation templates in iot-x-energy-monitoring have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.